### PR TITLE
fix(types): default props & emotion css 타입 관련 에러 수정

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -10,6 +10,8 @@ module.exports = {
 		'react/react-in-jsx-scope': 'off',
 		'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
 		'import/prefer-default-export': 'off',
+		// default props를 설정하지 않았을 때 에러를 반환하는 기능 제거
+		'react/require-default-props': 'off',
 		// airbnb eslint의 import/extensions 조건을 해제하는 옵션
 		'import/extensions': [
 			'error',

--- a/src/types/styled.d.ts
+++ b/src/types/styled.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@emotion/react/types/css-prop" />


### PR DESCRIPTION
## 📍 작업 내용
Component.defaultProps 메서드를 사용하지 않고 컴포넌트의 인자를 받아오는 단계에서 default props를 설정해주었습니다. 하지만 왜 그런지는 모르겠는데 default props를 인식을 못하길래 eslint에서 에러를 뱉어내는 옵션을 꺼주었습니다.